### PR TITLE
Java compatability gubbins

### DIFF
--- a/bricks-ddd/src/main/java/io/induct/domain/Entity.java
+++ b/bricks-ddd/src/main/java/io/induct/domain/Entity.java
@@ -1,12 +1,17 @@
 package io.induct.domain;
 
+import java.io.Serializable;
+import java.util.Objects;
+
 /**
  * Immutable base implementation for {@link Identifiable}. Uses default fallback value for detecting identification
  * state.
  *
  * @since 2015-03-29
  */
-public abstract class Entity<I> implements Identifiable<I> {
+public abstract class Entity<I extends Serializable & Comparable<I>>
+        implements Identifiable<I>, Serializable, Comparable<Entity<I>> {
+
     private final I identity;
     private final I unidentifiedIdentity;
 
@@ -28,5 +33,28 @@ public abstract class Entity<I> implements Identifiable<I> {
     @Override
     public boolean isUnidentified() {
         return identity.equals(unidentifiedIdentity);
+    }
+
+    @Override
+    public int compareTo(Entity<I> o) {
+        return identity.compareTo(o.identity);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identity, unidentifiedIdentity);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final Entity other = (Entity) obj;
+        return Objects.equals(this.identity, other.identity)
+                && Objects.equals(this.unidentifiedIdentity, other.unidentifiedIdentity);
     }
 }


### PR DESCRIPTION
implement Serializable and Comparator interfaces and hashCode/equals in favor of better extendability and using Entity in OO manner if the user chooses to do so